### PR TITLE
kafka-reassign-tools: fix log_dirs

### DIFF
--- a/kafka-reassign-tool
+++ b/kafka-reassign-tool
@@ -276,6 +276,9 @@ def set_replication(assignments, brokers, replication_factor)
     item = item.clone()
     item['replicas'] = replicas
 
+    # Create just enough log_dirs configuration
+    item['log_dirs'] = item['replicas'].count.times.map { |x| "any" }
+
     new_assignments << item
   }
 


### PR DESCRIPTION
The kafka-reassign-partitions.sh complies if the number of the log_dirs
isn't the same as the number of the brokers.

This small patch creates the appropriate number of log_dirs entries.
Please note that it will use the "any" string for every broker!