### PR TITLE
Fixed missing log_dirs in the parition reassign generate json

### DIFF
--- a/kafka-reassign-tool
+++ b/kafka-reassign-tool
@@ -276,6 +276,9 @@ def set_replication(assignments, brokers, replication_factor)
     item = item.clone()
     item['replicas'] = replicas
 
+    item['log_dirs'].clear
+    item['log_dirs'] = ["any"] * replicas.size
+
     new_assignments << item
   }
 


### PR DESCRIPTION
Kafka 2.* reassign partition is in this format

```
{"version":1,
 "partitions":
   [{"topic":"mytopic1","partition":3,"replicas":[4,5],"log_dirs":["any","any"]},
    {"topic":"mytopic1","partition":1,"replicas":[5,4],"log_dirs":["any","any"]},
    {"topic":"mytopic2","partition":2,"replicas":[6,5],"log_dirs":["any","any"]}]
}
```

So when we change the number of replicas, we need to change log_dirs as well.